### PR TITLE
feat: replace async, xml2js, yaml, and SDR with in-house parsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,7 @@
       "dependencies": {
         "@oclif/core": "4.13.5",
         "@salesforce/core": "8.32.6",
-        "@salesforce/sf-plugins-core": "12.2.28",
-        "@salesforce/source-deploy-retrieve": "12.37.2",
-        "async": "3.2.6",
-        "xml2js": "0.6.2",
-        "yaml": "2.9.0"
+        "@salesforce/sf-plugins-core": "12.2.28"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
@@ -25,9 +21,7 @@
         "@salesforce/dev-config": "4.3.3",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/vitest-runner": "9.6.1",
-        "@types/async": "3.2.25",
         "@types/node": "22.20.1",
-        "@types/xml2js": "0.4.14",
         "@vitest/coverage-v8": "4.1.11",
         "husky": "9.1.7",
         "lint-staged": "17.3.0",
@@ -2384,16 +2378,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -3286,63 +3270,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.37.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.2.tgz",
-      "integrity": "sha512-wgG0RccjQ8CaBEO8woSvvTyxc6V7KIw1GbZlME0bU+Ly+2G8pdPHAm43hrBTBml5MdYVh3J3yZwMyIeRaQxeBA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@salesforce/core": "^8.32.2",
-        "@salesforce/kit": "^3.2.4",
-        "@salesforce/ts-types": "^2.0.12",
-        "@salesforce/types": "^1.6.0",
-        "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^5.7.3",
-        "got": "^11.8.6",
-        "graceful-fs": "^4.2.11",
-        "ignore": "^5.3.2",
-        "jszip": "^3.10.1",
-        "mime": "2.6.0",
-        "minimatch": "^9.0.9",
-        "proxy-agent": "^6.5.0",
-        "yaml": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
-      "version": "9.0.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@salesforce/ts-types": {
       "version": "2.0.12",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/types": {
-      "version": "1.7.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -4169,20 +4101,6 @@
         "vitest": ">=2.0.0"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "license": "MIT"
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
@@ -4202,23 +4120,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/async": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.25.tgz",
-      "integrity": "sha512-O6Th/DI18XjrL9TX8LO9F/g26qAz5vynmQqlXt/qLGrskvzCKXKc5/tATz3G2N6lM8eOf3M8/StB14FncAmocg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4255,14 +4156,8 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
@@ -4276,6 +4171,7 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4297,13 +4193,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/shelljs": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.10.0.tgz",
@@ -4319,14 +4208,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/xml2js": {
-      "version": "0.4.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.11",
@@ -4504,13 +4385,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -4629,16 +4503,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
@@ -4660,6 +4524,7 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-retry": {
@@ -4697,6 +4562,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4737,13 +4603,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -4844,13 +4703,6 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.6.0"
-      }
     },
     "node_modules/cacheable-request": {
       "version": "10.2.14",
@@ -5251,23 +5103,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clone-response/node_modules/mimic-response": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -5517,13 +5352,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "license": "MIT",
@@ -5548,6 +5376,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -5561,21 +5390,10 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -5789,43 +5607,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5834,13 +5615,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -6043,42 +5817,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
-      }
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -6329,18 +6067,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/git-raw-commits": {
       "version": "4.0.0",
       "dev": true,
@@ -6419,58 +6145,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/got/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -6555,6 +6229,7 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-call": {
@@ -6594,28 +6269,6 @@
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -6682,13 +6335,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/immediate": {
       "version": "3.0.6",
@@ -6951,21 +6597,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/ip-address": {
-      "version": "9.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "license": "BSD-3-Clause"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -7275,10 +6906,6 @@
         "xmlcreate": "^2.0.4"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7294,6 +6921,7 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -7445,6 +7073,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -7897,13 +7526,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "dev": true,
@@ -8016,16 +7638,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -8058,6 +7670,7 @@
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8187,13 +7800,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8238,16 +7844,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-path": {
@@ -8475,13 +8071,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -8490,45 +8079,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/pako": {
@@ -8607,19 +8157,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -8872,45 +8409,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "license": "MIT",
@@ -8960,6 +8458,7 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9084,6 +8583,7 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -9092,16 +8592,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -9508,14 +8998,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "license": "MIT",
@@ -9524,43 +9006,11 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/socks": {
-      "version": "2.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/sonic-boom": {
       "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -9711,16 +9161,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10110,6 +9550,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -10579,19 +10020,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "license": "MIT",
@@ -10633,7 +10061,9 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "dependencies": {
     "@oclif/core": "4.13.5",
     "@salesforce/core": "8.32.6",
-    "@salesforce/sf-plugins-core": "12.2.28",
-    "@salesforce/source-deploy-retrieve": "12.37.2",
-    "async": "3.2.6",
-    "xml2js": "0.6.2",
-    "yaml": "2.9.0"
+    "@salesforce/sf-plugins-core": "12.2.28"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.9",
@@ -19,9 +15,7 @@
     "@salesforce/dev-config": "4.3.3",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",
-    "@types/async": "3.2.25",
     "@types/node": "22.20.1",
-    "@types/xml2js": "0.4.14",
     "@vitest/coverage-v8": "4.1.11",
     "husky": "9.1.7",
     "lint-staged": "17.3.0",
@@ -79,8 +73,8 @@
     "prepack": "wireit",
     "prepare": "husky",
     "test": "wireit",
-    "test:mutation": "stryker run",
-    "test:mutation:incremental": "node scripts/incremental-mutation.mjs",
+    "test:mutation": "wireit",
+    "test:mutation:incremental": "wireit",
     "test:nuts": "wireit",
     "test:only": "wireit"
   },
@@ -182,6 +176,39 @@
       "dependencies": [
         "test:compile",
         "test:only",
+        "lint"
+      ]
+    },
+    "test:mutation": {
+      "command": "stryker run",
+      "files": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "**/tsconfig.json",
+        "stryker.config.json",
+        "vitest.config.ts"
+      ],
+      "output": [
+        "reports/mutation/**"
+      ],
+      "dependencies": [
+        "lint"
+      ]
+    },
+    "test:mutation:incremental": {
+      "command": "node scripts/incremental-mutation.mjs",
+      "files": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "**/tsconfig.json",
+        "stryker.config.json",
+        "vitest.config.ts",
+        "scripts/incremental-mutation.mjs"
+      ],
+      "output": [
+        "reports/mutation/**"
+      ],
+      "dependencies": [
         "lint"
       ]
     },

--- a/src/parsers/manifestParser.ts
+++ b/src/parsers/manifestParser.ts
@@ -1,7 +1,20 @@
 'use strict';
 
 import { existsSync } from 'node:fs';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { readFile } from 'node:fs/promises';
+import { findChild, findChildren, parseXml } from '../utils/xmlParser.js';
+
+// Salesforce's metadata registry resolves type names case-insensitively;
+// manifests may declare them in any case (e.g. "apexclass"), but downstream
+// consumers compare against the canonical capitalization.
+const CANONICAL_TYPE_NAMES: Record<string, string> = {
+  apexclass: 'ApexClass',
+  apextrigger: 'ApexTrigger',
+};
+
+function canonicalTypeName(typeName: string): string {
+  return CANONICAL_TYPE_NAMES[typeName.toLowerCase()] ?? typeName;
+}
 
 /**
  * Given a certain manifest file, reads that file and returns the classes,
@@ -19,10 +32,17 @@ export async function extractTypeNamesFromManifestFile(manifestFile: string): Pr
     return result;
   }
 
-  const componentSet: ComponentSet = await ComponentSet.fromManifest({ manifestPath: manifestFile });
-  for (const component of componentSet) {
-    const typeName = component.type.name;
-    result.push(`${typeName}:${component.fullName}`);
+  const content = await readFile(manifestFile, 'utf-8');
+  const root = parseXml(content);
+
+  for (const typesElement of findChildren(root, 'types')) {
+    const nameElement = findChild(typesElement, 'name');
+    if (!nameElement) continue;
+
+    const typeName = canonicalTypeName(nameElement.text.trim());
+    for (const memberElement of findChildren(typesElement, 'members')) {
+      result.push(`${typeName}:${memberElement.text.trim()}`);
+    }
   }
 
   return result.sort((a, b) => a.localeCompare(b));

--- a/src/parsers/metadataFilterParser.ts
+++ b/src/parsers/metadataFilterParser.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
-import { parse } from 'yaml';
 
 import { TestMetadataMap } from '../utils/types.js';
+import { parseYaml } from '../utils/yamlParser.js';
 
 /**
  * Verifies structure matches the test metadata map type.
@@ -20,7 +20,7 @@ function isTestMetadataMap(obj: unknown): obj is TestMetadataMap {
  */
 export async function loadTestMetadataDependencies(configPath: string): Promise<TestMetadataMap> {
   const content = await readFile(configPath, 'utf-8');
-  const parsed: unknown = parse(content);
+  const parsed: unknown = parseYaml(content);
 
   if (isTestMetadataMap(parsed)) {
     return parsed;

--- a/src/parsers/testSuiteParser.ts
+++ b/src/parsers/testSuiteParser.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Parser } from 'xml2js';
+import { findChildren, parseXml } from '../utils/xmlParser.js';
 
 /**
  * Analyzes the content of a test suite xml file and returns the Apex classes
@@ -10,18 +10,15 @@ import { Parser } from 'xml2js';
  * @returns a list of test classes names in the test suite
  */
 export function parseTestSuiteFile(data: string): string[] {
-  const result: string[] = [];
+  const root = parseXml(data);
 
-  new Parser().parseString(data, (error, parsed: { ApexTestSuite: { testClassName: string[] } }) => {
-    if (error) {
-      throw error;
-    }
-    parsed.ApexTestSuite.testClassName.forEach((testSuite) => {
-      result.push(testSuite);
-    });
-  });
+  if (root.name !== 'ApexTestSuite') {
+    throw new Error(`Invalid XML: expected root element "ApexTestSuite", got "${root.name}"`);
+  }
 
-  return result.sort();
+  return findChildren(root, 'testClassName')
+    .map((element) => element.text.trim())
+    .sort();
 }
 
 /**

--- a/src/readers/directorySearcher.ts
+++ b/src/readers/directorySearcher.ts
@@ -2,10 +2,10 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
-import { queue } from 'async';
 import { parseTestsNames } from '../parsers/testNameParser.js';
 import { parseTestSuitesNames } from '../parsers/testSuiteParser.js';
 import { getConcurrencyThreshold } from '../utils/concurrencyThreshold.js';
+import { createQueue } from '../utils/concurrentQueue.js';
 import { TEST_CLASS_ANNOTATION_REGEX, TEST_NAME_REGEX, TEST_SUITE_NAME_REGEX } from '../utils/constants.js';
 import { SearchResult } from '../utils/types.js';
 
@@ -68,6 +68,9 @@ export async function searchDirectoryForTestClasses(directory: string, names: st
       }
     }
 
+    // Stryker disable next-line ConditionalExpression,EqualityOperator: String.match()
+    // with a global regex returns either null or a non-empty array — the length
+    // check is equivalent to a plain truthy check here.
     if (testClassAnnotationMatches && testClassAnnotationMatches.length > 0) {
       hasAnnotation = true;
       testClassesNames.add(basename(fileName).split('.').shift() as string);
@@ -78,7 +81,7 @@ export async function searchDirectoryForTestClasses(directory: string, names: st
     }
   };
 
-  const testClassNameProcessor = queue((f: string, cb: (error?: Error | undefined) => void) => {
+  const testClassNameProcessor = createQueue((f: string, cb: (error?: Error | undefined) => void) => {
     testClassNameHandler(f);
     cb();
   }, getConcurrencyThreshold());

--- a/src/readers/testSuiteSearcher.ts
+++ b/src/readers/testSuiteSearcher.ts
@@ -1,10 +1,9 @@
 'use strict';
 
 import { readdirSync, readFileSync } from 'node:fs';
-import { queue } from 'async';
-
 import { parseTestSuiteFile } from '../parsers/testSuiteParser.js';
 import { getConcurrencyThreshold } from '../utils/concurrencyThreshold.js';
+import { createQueue } from '../utils/concurrentQueue.js';
 import { matchWildcard } from '../utils/matchWildcard.js';
 import { searchDirectoryForTestClasses } from './directorySearcher.js';
 
@@ -54,7 +53,7 @@ export async function searchDirectoryForTestNamesInTestSuites(
   };
 
   // define the processors
-  const testSuiteNameProcessor = queue((f: string, cb: (error?: Error | undefined) => void) => {
+  const testSuiteNameProcessor = createQueue((f: string, cb: (error?: Error | undefined) => void) => {
     testSuiteNameHandler(f);
     cb();
   }, getConcurrencyThreshold());

--- a/src/utils/concurrentQueue.ts
+++ b/src/utils/concurrentQueue.ts
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Minimal in-house replacement for async's `queue`: runs a worker over a
+ * list of tasks with a concurrency cap, resolving once all tasks finish
+ * (or rejecting on the first error).
+ */
+
+type Worker<T> = (task: T, callback: (error?: Error) => void) => void;
+
+export interface ConcurrentQueue<T> {
+  push(tasks: T | T[]): Promise<void>;
+}
+
+export function createQueue<T>(worker: Worker<T>, concurrency: number): ConcurrentQueue<T> {
+  return {
+    push(tasks: T | T[]): Promise<void> {
+      const items = Array.isArray(tasks) ? tasks : [tasks];
+
+      return new Promise<void>((resolvePromise, reject) => {
+        if (items.length === 0) {
+          resolvePromise();
+          return;
+        }
+
+        let index = 0;
+        let active = 0;
+        let settled = false;
+
+        const runNext = (): void => {
+          while (!settled && active < concurrency && index < items.length) {
+            const item = items[index++];
+            active++;
+            worker(item, (error) => {
+              // Stryker disable next-line ConditionalExpression: redundant with
+              // runNext()'s own `!settled` check below — even without this early
+              // return, a late callback can only ever reach a no-op runNext()
+              // call once settled is true, since that check blocks it too.
+              if (settled) return;
+              if (error) {
+                settled = true;
+                reject(error);
+                return;
+              }
+              active--;
+              if (index >= items.length && active === 0) {
+                // Stryker disable next-line BooleanLiteral: this branch only
+                // fires once every item is dispatched (index >= items.length),
+                // which independently blocks runNext()'s while loop from ever
+                // dispatching again, regardless of this assignment's value.
+                settled = true;
+                resolvePromise();
+                return;
+              }
+              runNext();
+            });
+          }
+        };
+
+        runNext();
+      });
+    },
+  };
+}

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * Minimal in-house XML parser. Handles the narrow subset of well-formed XML
+ * used by Salesforce metadata files consumed by this plugin (package
+ * manifests and test suite files): nested elements, comments, processing
+ * instructions, self-closing tags, and basic entity-decoded text content.
+ */
+
+export interface XmlElement {
+  name: string;
+  children: XmlElement[];
+  text: string;
+}
+
+// The tag alternative has no separate "whitespace before attributes" check:
+// [^<>]* already includes whitespace, so an optional leading \s would only
+// ever be satisfied via a redundant backtrack into the tag-name class.
+const TOKEN_REGEX = /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<\/?[a-zA-Z_][\w.:-]*[^<>]*\/?>/g;
+// Stryker disable next-line Regex: TAG_NAME_REGEX only ever runs on a `token`
+// that is itself a full TOKEN_REGEX match, which always starts with '<' and
+// (once comments/PIs are excluded above) can never contain another '<', so
+// the leading '^' anchor can never change which substring matches.
+const TAG_NAME_REGEX = /^<\/?([a-zA-Z_][\w.:-]*)/;
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+export function parseXml(xml: string): XmlElement {
+  const stack: XmlElement[] = [];
+  let root: XmlElement | undefined;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  const pushText = (raw: string): void => {
+    if (!raw.trim() || stack.length === 0) return;
+    stack[stack.length - 1].text += decodeEntities(raw);
+  };
+
+  TOKEN_REGEX.lastIndex = 0;
+  while ((match = TOKEN_REGEX.exec(xml)) !== null) {
+    pushText(xml.slice(lastIndex, match.index));
+    lastIndex = TOKEN_REGEX.lastIndex;
+
+    const token = match[0];
+    if (token.startsWith('<!--') || token.startsWith('<?')) {
+      continue;
+    }
+
+    // TOKEN_REGEX already constrains every non-comment/PI token to this exact
+    // tag-name pattern, so the exec() below is guaranteed to match.
+    const name = TAG_NAME_REGEX.exec(token)![1];
+
+    if (token.startsWith('</')) {
+      const current = stack.pop();
+      if (!current || current.name !== name) {
+        throw new Error(`Invalid XML: mismatched closing tag "${token}"`);
+      }
+      // Stryker disable next-line ConditionalExpression: in well-formed,
+      // single-root XML the true root's own closing/self-closing token is
+      // always the last one processed, so it always overwrites any earlier,
+      // premature assignment here regardless of this guard.
+      if (stack.length === 0) {
+        root = current;
+      }
+      continue;
+    }
+
+    const element: XmlElement = { name, children: [], text: '' };
+    if (stack.length > 0) {
+      stack[stack.length - 1].children.push(element);
+    }
+
+    if (token.endsWith('/>')) {
+      // Stryker disable next-line ConditionalExpression: same reasoning as the
+      // closing-tag branch above — the last root-setting assignment always wins.
+      if (stack.length === 0) root = element;
+    } else {
+      stack.push(element);
+    }
+  }
+
+  if (stack.length > 0) {
+    throw new Error(`Invalid XML: unclosed tag "<${stack[stack.length - 1].name}>"`);
+  }
+  if (!root) {
+    throw new Error('Invalid XML: no root element found');
+  }
+
+  return root;
+}
+
+export function findChildren(element: XmlElement, name: string): XmlElement[] {
+  return element.children.filter((child) => child.name === name);
+}
+
+export function findChild(element: XmlElement, name: string): XmlElement | undefined {
+  return element.children.find((child) => child.name === name);
+}

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Minimal in-house YAML parser covering the narrow subset used by this
+ * plugin's test-metadata-dependencies file: a flat mapping of scalar keys
+ * to either a scalar value or a block sequence of scalars. Not a general
+ * YAML implementation.
+ */
+
+function parseScalar(raw: string): unknown {
+  const text = raw.trim();
+
+  if (text === '' || text === '~' || /^null$/i.test(text)) return null;
+  if (/^true$/i.test(text)) return true;
+  if (/^false$/i.test(text)) return false;
+  if (/^-?\d+(\.\d+)?$/.test(text)) return Number(text);
+  if (
+    text.length >= 2 &&
+    ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("'") && text.endsWith("'")))
+  ) {
+    return text.slice(1, -1);
+  }
+
+  return text;
+}
+
+// No trailing $: rawLine is always a single line (already split on '\n'), and
+// `.` never matches '\n', so `(.*)` already extends to the end of the string.
+const TOP_LEVEL_KEY_REGEX = /^(\S[^:]*):\s*(.*)/;
+const LIST_ITEM_REGEX = /^[ \t]+-\s?(.*)/;
+
+export function parseYaml(content: string): unknown {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const result: Record<string, unknown> = {};
+  let currentKey: string | null = null;
+  let currentList: unknown[] | null = null;
+  let sawKey = false;
+
+  const commitPending = (): void => {
+    if (currentKey !== null) {
+      result[currentKey] = currentList ?? null;
+    }
+    currentKey = null;
+    currentList = null;
+  };
+
+  // A blank (or whitespace-only) line matches neither LIST_ITEM_REGEX (no
+  // dash) nor TOP_LEVEL_KEY_REGEX (no non-whitespace first character), so it
+  // is already skipped by the "not a key, not a list item" fallthrough below
+  // — no separate blank-line check needed.
+  for (const rawLine of lines) {
+    const listMatch = LIST_ITEM_REGEX.exec(rawLine);
+    // Stryker disable next-line ConditionalExpression: commitPending() always
+    // resets currentList before a new key can pick it up, so a list item seen
+    // while currentKey is null can never leak into the result either way.
+    if (listMatch && currentKey !== null) {
+      currentList = currentList ?? [];
+      currentList.push(parseScalar(listMatch[1]));
+      continue;
+    }
+
+    // A line indented with space/tab can never match TOP_LEVEL_KEY_REGEX below
+    // (it requires a non-whitespace first character), so it already falls
+    // through to the "not a key" branch on its own — no separate guard needed.
+
+    const keyMatch = TOP_LEVEL_KEY_REGEX.exec(rawLine);
+    if (!keyMatch) {
+      continue;
+    }
+
+    commitPending();
+    sawKey = true;
+    const key = keyMatch[1].trim();
+    const inline = keyMatch[2];
+
+    // TOP_LEVEL_KEY_REGEX's `\s*` already consumes any whitespace right after
+    // the colon, so `inline` can never be non-empty and whitespace-only.
+    if (inline) {
+      result[key] = parseScalar(inline);
+    } else {
+      currentKey = key;
+    }
+  }
+
+  commitPending();
+
+  // parseScalar() trims internally, so pre-trimming content here is redundant.
+  return sawKey ? result : parseScalar(content);
+}

--- a/test/units/parsers.test.ts
+++ b/test/units/parsers.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { unlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -36,6 +36,51 @@ describe('tests of the extractTypeNamesFromManifestFile fn', () => {
       result.findIndex((r) => r.startsWith('ApexTrigger')),
     );
   });
+
+  it('should skip a <types> block that has no <name>', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'manifest-no-name-'));
+    const manifestPath = join(tempDir, 'noName.xml');
+    await writeFile(
+      manifestPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>Orphan</members>
+  </types>
+  <types>
+    <members>Sample</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`,
+    );
+    try {
+      const result = await extractTypeNamesFromManifestFile(manifestPath);
+      expect(result).to.deep.equal(['ApexClass:Sample']);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('should trim whitespace around <name> and <members> text', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'manifest-padded-'));
+    const manifestPath = join(tempDir, 'padded.xml');
+    await writeFile(
+      manifestPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>  Sample  </members>
+    <name>  ApexClass  </name>
+  </types>
+</Package>`,
+    );
+    try {
+      const result = await extractTypeNamesFromManifestFile(manifestPath);
+      expect(result).to.deep.equal(['ApexClass:Sample']);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
 });
 
 describe('tests of the parseTestSuiteFile fn', () => {
@@ -57,6 +102,18 @@ describe('tests of the parseTestSuiteFile fn', () => {
     } catch (e) {
       expect(e).not.toBeInstanceOf(TypeError);
     }
+  });
+
+  it('should throw when the root element is not ApexTestSuite', () => {
+    expect(() => parseTestSuiteFile('<NotApexTestSuite/>')).toThrow(
+      'expected root element "ApexTestSuite", got "NotApexTestSuite"',
+    );
+  });
+
+  it('should trim whitespace around <testClassName> text', () => {
+    const xml =
+      '<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata"><testClassName>  PaddedTest  </testClassName></ApexTestSuite>';
+    expect(parseTestSuiteFile(xml)).to.deep.equal(['PaddedTest']);
   });
 });
 

--- a/test/units/readers.test.ts
+++ b/test/units/readers.test.ts
@@ -49,6 +49,15 @@ describe('searchDirectoryForTestClasses error handling', () => {
       'Invalid or inaccessible directory',
     );
   });
+
+  it('should preserve the original error as the cause', async () => {
+    try {
+      await searchDirectoryForTestClasses('/nonexistent/invalid/path', null);
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect((e as Error).cause).toBeInstanceOf(Error);
+    }
+  });
 });
 
 describe('searchDirectoryForTestNamesInTestSuites error handling', () => {
@@ -56,6 +65,15 @@ describe('searchDirectoryForTestNamesInTestSuites error handling', () => {
     await expect(searchDirectoryForTestNamesInTestSuites('/nonexistent/invalid/path', [])).rejects.toThrow(
       'Invalid or inaccessible directory',
     );
+  });
+
+  it('should preserve the original error as the cause', async () => {
+    try {
+      await searchDirectoryForTestNamesInTestSuites('/nonexistent/invalid/path', []);
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect((e as Error).cause).toBeInstanceOf(Error);
+    }
   });
 });
 

--- a/test/units/utils.test.ts
+++ b/test/units/utils.test.ts
@@ -3,9 +3,12 @@ import { availableParallelism, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getConcurrencyThreshold } from '../../src/utils/concurrencyThreshold.js';
+import { createQueue } from '../../src/utils/concurrentQueue.js';
 import { formatList } from '../../src/utils/formatters.js';
 import { getRepoRoot } from '../../src/utils/getRepoRoot.js';
 import { validateTests } from '../../src/utils/validateTests.js';
+import { findChild, parseXml } from '../../src/utils/xmlParser.js';
+import { parseYaml } from '../../src/utils/yamlParser.js';
 
 describe('formatList', () => {
   it('sfdx format joins tests with space', async () => {
@@ -79,5 +82,310 @@ describe('getConcurrencyThreshold', () => {
   it('returns Math.min of availableParallelism and 6', () => {
     const result = getConcurrencyThreshold();
     expect(result).toBe(Math.min(availableParallelism(), 6));
+  });
+});
+
+describe('createQueue', () => {
+  it('resolves once every task completes', async () => {
+    const processed: number[] = [];
+    const q = createQueue<number>((task, cb) => {
+      processed.push(task);
+      cb();
+    }, 2);
+
+    await q.push([1, 2, 3]);
+    expect(processed.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('resolves immediately when pushed an empty array', async () => {
+    const q = createQueue<number>((_task, cb) => cb(), 2);
+    await expect(q.push([])).resolves.toBeUndefined();
+  });
+
+  it('rejects when a worker reports an error', async () => {
+    const q = createQueue<number>((task, cb) => {
+      cb(task === 2 ? new Error('boom') : undefined);
+    }, 2);
+
+    await expect(q.push([1, 2, 3])).rejects.toThrow('boom');
+  });
+
+  it('accepts a single non-array task', async () => {
+    const processed: number[] = [];
+    const q = createQueue<number>((task, cb) => {
+      processed.push(task);
+      cb();
+    }, 1);
+
+    await q.push(5);
+    expect(processed).toEqual([5]);
+  });
+
+  it('ignores late callbacks that arrive after the queue has already settled', async () => {
+    const started: number[] = [];
+    const q = createQueue<number>((task, cb) => {
+      started.push(task);
+      if (task === 1) {
+        // deferred (not synchronous) so task 2 also gets dispatched in the
+        // same synchronous pass before either callback fires
+        Promise.resolve().then(() => cb(new Error('first')));
+      } else if (task === 2) {
+        setTimeout(() => cb(), 0);
+      } else {
+        cb();
+      }
+    }, 2);
+
+    await expect(q.push([1, 2, 3])).rejects.toThrow('first');
+    // let the deferred, post-settlement callback for task 2 fire and hit the guard
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    // task 3 must never start: the queue must actually record itself as
+    // settled, not just resolve the promise once, or a late callback would
+    // wake runNext() and dispatch the remaining task
+    expect(started).toEqual([1, 2]);
+  });
+
+  it('never runs more tasks concurrently than the configured concurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const q = createQueue<number>((_task, cb) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      setTimeout(() => {
+        active--;
+        cb();
+      }, 5);
+    }, 2);
+
+    await q.push([1, 2, 3, 4, 5]);
+    expect(maxActive).toBe(2);
+  });
+
+  it('does not resolve until every dispatched task has actually completed', async () => {
+    const callbacks: Array<() => void> = [];
+    const q = createQueue<number>((_task, cb) => {
+      callbacks.push(cb);
+    }, 3);
+
+    const pushPromise = q.push([1, 2, 3]);
+    let resolved = false;
+    pushPromise.then(() => {
+      resolved = true;
+    });
+
+    // concurrency (3) >= task count, so all 3 dispatch synchronously
+    expect(callbacks).toHaveLength(3);
+
+    callbacks[0]();
+    callbacks[1]();
+    await Promise.resolve(); // flush microtasks
+    expect(resolved).toBe(false);
+
+    callbacks[2]();
+    await pushPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('never invokes the worker more times than there are tasks', async () => {
+    // concurrency (5) deliberately exceeds the task count (3), and the
+    // worker defers its callback so the initial synchronous dispatch loop
+    // gets a chance to over-run the task list before any task completes
+    let calls = 0;
+    const q = createQueue<number>((_task, cb) => {
+      calls++;
+      setTimeout(cb, 0);
+    }, 5);
+
+    await q.push([1, 2, 3]);
+    expect(calls).toBe(3);
+  });
+});
+
+describe('parseXml', () => {
+  it('parses a self-closing root element', () => {
+    const root = parseXml('<Foo/>');
+    expect(root.name).toBe('Foo');
+    expect(root.children).toEqual([]);
+  });
+
+  it('parses a nested self-closing element', () => {
+    const root = parseXml('<Foo><Bar/></Foo>');
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].name).toBe('Bar');
+  });
+
+  it('throws on a closing tag with no matching open tag', () => {
+    expect(() => parseXml('</a>')).toThrow('mismatched closing tag');
+  });
+
+  it('throws on a mismatched closing tag', () => {
+    expect(() => parseXml('<a><b></c></a>')).toThrow('mismatched closing tag');
+  });
+
+  it('throws on an unclosed tag', () => {
+    expect(() => parseXml('<a><b></b>')).toThrow('unclosed tag');
+  });
+
+  it('findChild returns undefined when no matching child exists', () => {
+    const root = parseXml('<a><b/></a>');
+    expect(findChild(root, 'c')).toBeUndefined();
+  });
+
+  it('decodes each XML entity to its correct character', () => {
+    const root = parseXml('<a>&lt;&gt;&quot;&apos;&amp;</a>');
+    expect(root.text).toBe(`<>"'&`);
+  });
+
+  it('throws the specific "no root element found" message on unparsable input', () => {
+    expect(() => parseXml('<<< not valid xml >>>')).toThrow('no root element found');
+  });
+
+  it('ignores whitespace-only text between sibling tags', () => {
+    const root = parseXml('<a>   <b/></a>');
+    expect(root.text).toBe('');
+  });
+
+  it('ignores non-blank text found outside any element', () => {
+    const root = parseXml('lead<a></a>');
+    expect(root.name).toBe('a');
+    expect(root.text).toBe('');
+  });
+
+  it('skips a comment containing both whitespace and non-whitespace characters', () => {
+    const root = parseXml('<a><!-- a longer comment --><b/></a>');
+    expect(root.text).toBe('');
+    expect(root.children).toHaveLength(1);
+  });
+
+  it('skips a processing instruction with multi-character content', () => {
+    const root = parseXml('<a><?target multi word instruction?><b/></a>');
+    expect(root.text).toBe('');
+    expect(root.children).toHaveLength(1);
+  });
+
+  it('parses a tag with attributes as a single token', () => {
+    const root = parseXml('<Package xmlns="http://soap.sforce.com/2006/04/metadata"><types/></Package>');
+    expect(root.name).toBe('Package');
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].name).toBe('types');
+  });
+});
+
+describe('parseYaml', () => {
+  it('parses a flat mapping of scalar keys to lists', () => {
+    expect(parseYaml('Foo:\n  - Bar\n  - Baz\n')).toEqual({ Foo: ['Bar', 'Baz'] });
+  });
+
+  it('ignores an indented line that is not a list item', () => {
+    expect(parseYaml('Foo:\n  - Bar\n  not-a-list-item\nBaz:\n  - Qux\n')).toEqual({
+      Foo: ['Bar'],
+      Baz: ['Qux'],
+    });
+  });
+
+  it('parses inline scalar values', () => {
+    expect(parseYaml('count: 3\nflag: true\nother: false\nname: hello')).toEqual({
+      count: 3,
+      flag: true,
+      other: false,
+      name: 'hello',
+    });
+  });
+
+  it('returns a single-character scalar as-is', () => {
+    expect(parseYaml('key: x')).toEqual({ key: 'x' });
+  });
+
+  it('trims surrounding whitespace from a scalar value', () => {
+    expect(parseYaml('key:   42   ')).toEqual({ key: 42 });
+  });
+
+  it('trims surrounding whitespace from a key', () => {
+    const result = parseYaml('Foo   : value') as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual(['Foo']);
+    expect(result.Foo).toBe('value');
+  });
+
+  it('parses "null", "", and "~" as the null value', () => {
+    expect(parseYaml('null')).toBeNull();
+    expect(parseYaml('')).toBeNull();
+    expect(parseYaml('~')).toBeNull();
+  });
+
+  it('does not treat a string merely containing "null" as null', () => {
+    expect(parseYaml('nullish')).toBe('nullish');
+    expect(parseYaml('thisisnull')).toBe('thisisnull');
+  });
+
+  it('requires the full word for true/false, not just a prefix or suffix', () => {
+    expect(parseYaml('key: nottrue')).toEqual({ key: 'nottrue' });
+    expect(parseYaml('key: truely')).toEqual({ key: 'truely' });
+    expect(parseYaml('key: notfalse')).toEqual({ key: 'notfalse' });
+    expect(parseYaml('key: falsey')).toEqual({ key: 'falsey' });
+  });
+
+  it('parses decimal numbers', () => {
+    expect(parseYaml('key: 3.14')).toEqual({ key: 3.14 });
+  });
+
+  it('does not coerce a string merely containing digits into a number', () => {
+    expect(parseYaml('key: abc123')).toEqual({ key: 'abc123' });
+    expect(parseYaml('key: 123abc')).toEqual({ key: '123abc' });
+  });
+
+  it('returns an unterminated quote as a literal string', () => {
+    expect(parseYaml('key: "open')).toEqual({ key: '"open' });
+    expect(parseYaml("key: 'noclose")).toEqual({ key: "'noclose" });
+  });
+
+  it('does not strip a quote character that only appears at one end', () => {
+    expect(parseYaml('key: no"')).toEqual({ key: 'no"' });
+    expect(parseYaml("key: no'")).toEqual({ key: "no'" });
+  });
+
+  it('strips matching double quotes', () => {
+    expect(parseYaml('key: "double"')).toEqual({ key: 'double' });
+  });
+
+  it('strips matching single quotes', () => {
+    expect(parseYaml("key: 'single'")).toEqual({ key: 'single' });
+  });
+
+  it('strips quotes from a minimal two-character quoted pair', () => {
+    expect(parseYaml('key: ""')).toEqual({ key: '' });
+  });
+
+  it('does not strip a lone quote character (too short to be a pair)', () => {
+    expect(parseYaml("key: '")).toEqual({ key: "'" });
+    expect(parseYaml('key: "')).toEqual({ key: '"' });
+  });
+
+  it('sets a key with no value and no list items to null', () => {
+    expect(parseYaml('Foo:\n')).toEqual({ Foo: null });
+  });
+
+  it('normalizes CRLF line endings', () => {
+    expect(parseYaml('Foo:\r\n  - Bar\r\n')).toEqual({ Foo: ['Bar'] });
+  });
+
+  it('defers list items when the key line has only trailing whitespace after the colon', () => {
+    expect(parseYaml('Foo:    \n  - Bar\n')).toEqual({ Foo: ['Bar'] });
+  });
+
+  it('parses a list item with no space after the dash', () => {
+    expect(parseYaml('Foo:\n  -NoSpace\n')).toEqual({ Foo: ['NoSpace'] });
+  });
+
+  it('does not treat a key line as a list item just because it contains " - " later in the value', () => {
+    expect(parseYaml('Prev:\n  - Item\nFoo: bar - baz\n')).toEqual({
+      Prev: ['Item'],
+      Foo: 'bar - baz',
+    });
+  });
+
+  it('does not treat an indented, unsupported "key: value" line as a top-level key', () => {
+    expect(parseYaml('Foo:\n  - Bar\n  nested: value\n  - Baz\n')).toEqual({
+      Foo: ['Bar', 'Baz'],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Drops `@salesforce/source-deploy-retrieve`, `async`, `xml2js`, and `yaml` in favor of small in-house implementations scoped to exactly what this plugin needs, reducing the dependency attack surface (56 fewer transitive packages).
- Adds `src/utils/xmlParser.ts` (minimal XML parser), `src/utils/yamlParser.ts` (narrow YAML-subset parser), and `src/utils/concurrentQueue.ts` (concurrency-limited task queue) as drop-in replacements.
- `manifestParser.ts` now reads package.xml manifests directly instead of going through SDR's `ComponentSet`, preserving case-insensitive `ApexClass`/`ApexTrigger` type-name normalization.
- Hardened with unit tests to restore 100% statement/branch/function/line coverage and a 100% mutation-testing score on every touched file (verified via scoped `stryker run --mutate`), with `// Stryker disable` comments documenting the handful of mutants confirmed equivalent (e.g. a redundant guard that's always superseded by a later, correct assignment).
- If you're interested, this PR also sets you up to be able to publish this tool as a GitHub action as the only production dependencies are ones required to make this a Salesforce CLI oclif plugin. See https://github.com/mcarvin8/3dx which explains some of this, but you could easily publish this as a Salesforce CLI plugin and a GitHub action on marketplace for users who may want to use this without going through the CLI.

## Test plan
- [x] `npx vitest run --coverage` — 118 tests pass, 100% coverage
- [x] `npx biome check src test` — clean
- [x] `npx tsc -p .` / `npx tsc -p ./test` — clean
- [x] `npx stryker run --mutate <touched files>` — 100% mutation score, 0 survivors on every touched file
- [x] `npm run build` / `npm test` (pre-push hooks) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)