### PR TITLE
build: remove ts-node, run bin/dev against compiled lib

### DIFF
--- a/bin/dev.cmd
+++ b/bin/dev.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node --loader ts-node/esm --no-warnings=ExperimentalWarning "%~dp0\dev" %*
+node "%~dp0\dev" %*

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,8 +1,13 @@
-#!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
+#!/usr/bin/env node
 // eslint-disable-next-line node/shebang
+// oclif's dev-mode command discovery (development: true) reads tsconfig.json
+// via typescript's classic compiler API to locate src/*.ts, but TypeScript 7
+// removed that API, so discovery silently finds zero commands. Until
+// @oclif/core supports TS7, this runs the compiled ./lib output instead —
+// run `npm run compile` (or a watch) before using this script.
 async function main() {
   const { execute } = await import('@oclif/core');
-  await execute({ development: true, dir: import.meta.url });
+  await execute({ dir: import.meta.url });
 }
 
 await main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "lint-staged": "17.4.1",
         "oclif": "5.0.0",
         "shx": "0.4.0",
-        "ts-node": "10.9.2",
         "typescript": "7.0.2",
         "vitest": "5.0.0",
         "wireit": "0.14.13"
@@ -2044,26 +2043,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5291,26 +5270,6 @@
         "vitest": ">=2.0.0"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5845,28 +5804,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.12.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -5953,11 +5890,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6826,11 +6758,6 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6949,14 +6876,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-match-patch": {
@@ -9036,11 +8955,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -10849,48 +10763,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-retry-promise": {
       "version": "0.8.1",
       "license": "MIT",
@@ -11077,11 +10949,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -11616,14 +11483,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lint-staged": "17.4.1",
     "oclif": "5.0.0",
     "shx": "0.4.0",
-    "ts-node": "10.9.2",
     "typescript": "7.0.2",
     "vitest": "5.0.0",
     "wireit": "0.14.13"


### PR DESCRIPTION
## Summary
- ts-node doesn't work with TypeScript 7. Removed the `ts-node` devDependency and the `--loader ts-node/esm` flags from `bin/dev.cmd`/`bin/dev.js`.
- `@oclif/core@5.0.0` (latest) also breaks under TS7: its dev-mode command discovery calls `typescript.parseConfigFileTextToJson`, an API TS7 removed, so it silently finds zero commands. Not fixable on our side — upstream gap, same class of issue as the TS7/stryker incompatibility already worked around in `mutation.yml`.
- `bin/dev.js` now runs the compiled `./lib` output (same as `bin/run.js`) instead of live-transpiling `src`. Run `npm run compile` (or a watch) before using `bin/dev`.

## Test plan
- [x] `npm run compile` then `node bin/dev.js apextests list --help` prints full command help
- [x] `npm test` (build + test wireit scripts, ran via pre-push hook) passes
- [x] Confirmed no `ts-node` remains in `package-lock.json` or `node_modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sejk6a9jQFbfp7eRvcec7k